### PR TITLE
Fix writing to sys.stdout.buffer

### DIFF
--- a/ansi2html/converter.py
+++ b/ansi2html/converter.py
@@ -297,7 +297,7 @@ def main():
 
     def _print(output_unicode):
         if hasattr(sys.stdout, 'buffer'):
-            output_bytes = output_unicode.encode(opts.output_encoding)
+            output_bytes = (output_unicode + '\n').encode(opts.output_encoding)
             sys.stdout.buffer.write(output_bytes)
         elif not six.PY3:
             print(output_unicode.encode(opts.output_encoding))


### PR DESCRIPTION
Bug demonstration:

```
# for v in 2.7 3.2 ; do echo "Python ${v}:"; echo -e 'one\ntwo\nthree' | python${v} -c 'import sys; sys.path.insert(0, "."); from ansi2html.converter import main; main()' | wc -l ; done
Python 2.7:
521
Python 3.2:
520
```

In the code, you can see that in the first of these cases, the traling new line is omitted by mistake:

```
    def _print(output_unicode):
        if hasattr(sys.stdout, 'buffer'):
            output_bytes = output_unicode.encode(opts.output_encoding)
            sys.stdout.buffer.write(output_bytes)   # <-- no trailing newline
        elif not six.PY3:
            print(output_unicode.encode(opts.output_encoding))
        else:
            print(output_unicode)
```
