### PR TITLE
added support to select a color-scheme. added schemes 'xterm' and 'xterm...

### DIFF
--- a/ansi2html/converter.py
+++ b/ansi2html/converter.py
@@ -188,6 +188,7 @@ class Ansi2HTMLConverter(object):
                  escaped=True,
                  markup_lines=False,
                  output_encoding='utf-8',
+                 scheme='ansi2html'
                 ):
 
         self.inline = inline
@@ -197,10 +198,11 @@ class Ansi2HTMLConverter(object):
         self.escaped = escaped
         self.markup_lines = markup_lines
         self.output_encoding = output_encoding
+        self.scheme = scheme
         self._attrs = None
 
         if inline:
-            self.styles = dict([(item.klass.strip('.'), item) for item in get_styles(self.dark_bg)])
+            self.styles = dict([(item.klass.strip('.'), item) for item in get_styles(self.dark_bg, self.scheme)])
 
         self.ansi_codes_prog = re.compile('\033\\[' '([\\d;]*)' '([a-zA-z])')
 
@@ -365,7 +367,7 @@ class Ansi2HTMLConverter(object):
             return attrs["body"]
         else:
             return _template % {
-                'style' : "\n".join(map(str, get_styles(self.dark_bg))),
+                'style' : "\n".join(map(str, get_styles(self.dark_bg, self.scheme))),
                 'font_size' : self.font_size,
                 'content' :  attrs["body"],
                 'output_encoding' : self.output_encoding,
@@ -373,7 +375,7 @@ class Ansi2HTMLConverter(object):
 
     def produce_headers(self):
         return '<style type="text/css">\n%(style)s\n</style>\n' % {
-            'style' : "\n".join(map(str, get_styles(self.dark_bg)))
+            'style' : "\n".join(map(str, get_styles(self.dark_bg, self.scheme)))
         }
 
 
@@ -428,6 +430,10 @@ def main():
         '--output-encoding', dest='output_encoding', metavar='ENCODING',
         default='utf-8',
         help="Specify output encoding")
+    parser.add_option(
+        '-s', '--scheme', dest='scheme', metavar='SCHEME',
+        default='ansi2html',
+        help="Specify color palette scheme [ansi2html, xterm, xterm-bright]")
 
     opts, args = parser.parse_args()
 
@@ -439,6 +445,7 @@ def main():
         escaped=opts.escaped,
         markup_lines=opts.markup_lines,
         output_encoding=opts.output_encoding,
+        scheme=opts.scheme,
     )
 
     def _read(input_bytes):

--- a/ansi2html/style.py
+++ b/ansi2html/style.py
@@ -46,8 +46,17 @@ def level(grey):
 def index2(grey):
     return str(232 + grey)
 
+# http://en.wikipedia.org/wiki/ANSI_escape_code#Colors
+SCHEME = { # black red green brown/yellow blue magenta cyan grey/white
+    'ansi2html': ("#000316", "#aa0000", "#00aa00", "#aa5500", "#0000aa",
+                  "#E850A8", "#00aaaa", "#F5F1DE"),
+    'xterm': ("#000000", "#cd0000", "#00cd00", "#cdcd00", "#0000ee",
+              "#cd00cd", "#00cdcd", "#e5e5e5"),
+    'xterm-bright': ("#7f7f7f", "#ff0000", "#00ff00", "#ffff00", "#5c5cff",
+              "#ff00ff", "#00ffff", "#ffffff"),
+    }
 
-def get_styles(dark_bg=True):
+def get_styles(dark_bg=True, scheme='ansi2html'):
 
     css = [
         Rule('.body_foreground', color=('#000000', '#AAAAAA')[dark_bg]),
@@ -64,39 +73,17 @@ def get_styles(dark_bg=True):
         Rule('.ansi6', text_decoration='blink'),
         Rule('.ansi8', visibility='hidden'),
         Rule('.ansi9', text_decoration='line-through'),
-        Rule('.ansi30', color="#000316"),
-        Rule('.inv30', background_color="#000316"),
-        Rule('.ansi31', color="#aa0000"),
-        Rule('.inv31', background_color="#aa0000"),
-        Rule('.ansi32', color="#00aa00"),
-        Rule('.inv32', background_color="#00aa00"),
-        Rule('.ansi33', color="#aa5500"),
-        Rule('.inv33', background_color="#aa5500"),
-        Rule('.ansi34', color="#0000aa"),
-        Rule('.inv34', background_color="#0000aa"),
-        Rule('.ansi35', color="#E850A8"),
-        Rule('.inv35', background_color="#E850A8"),
-        Rule('.ansi36', color="#00aaaa"),
-        Rule('.inv36', background_color="#00aaaa"),
-        Rule('.ansi37', color="#F5F1DE"),
-        Rule('.inv37', background_color="#F5F1DE"),
-        Rule('.ansi40', background_color="#000316"),
-        Rule('.inv40', color="#000316"),
-        Rule('.ansi41', background_color="#aa0000"),
-        Rule('.inv41', color="#aa0000"),
-        Rule('.ansi42', background_color="#00aa00"),
-        Rule('.inv42', color="#00aa00"),
-        Rule('.ansi43', background_color="#aa5500"),
-        Rule('.inv43', color="#aa5500"),
-        Rule('.ansi44', background_color="#0000aa"),
-        Rule('.inv44', color="#0000aa"),
-        Rule('.ansi45', background_color="#E850A8"),
-        Rule('.inv45', color="#E850A8"),
-        Rule('.ansi46', background_color="#00aaaa"),
-        Rule('.inv46', color="#00aaaa"),
-        Rule('.ansi47', background_color="#F5F1DE"),
-        Rule('.inv47', color="#F5F1DE"),
         ]
+
+    # set palette
+    assert scheme in SCHEME
+    pal = SCHEME[scheme]
+    for _index in range(8):
+        css.append(Rule('.ansi3%s' % _index, color=pal[_index]))
+        css.append(Rule('.inv3%s' % _index, background_color=pal[_index]))
+    for _index in range(8):
+        css.append(Rule('.ansi4%s' % _index, background_color=pal[_index]))
+        css.append(Rule('.inv4%s' % _index, color=pal[_index]))
 
     # css.append("/* Define the explicit color codes (obnoxious) */\n\n")
 

--- a/tests/test_ansi2html.py
+++ b/tests/test_ansi2html.py
@@ -308,5 +308,17 @@ class TestAnsi2HTML(unittest.TestCase):
         expected = six.u('<span style="color: #aa0000">RED\nSTILL RED</span>\n')
         self.assertEqual(expected, html)
 
+    def test_scheme(self):  # covers issue 36, too
+        sample = '\x1b[33mYELLOW/BROWN'
+        # ansi2html scheme is brown #aa5500
+        html = Ansi2HTMLConverter(inline=True).convert(sample, full=False, ensure_trailing_newline=False)
+        expected = six.u('<span style="color: #aa5500">YELLOW/BROWN</span>')
+        self.assertEqual(expected, html)
+
+        # xterm scheme is yellow #cdcd00
+        html = Ansi2HTMLConverter(inline=True, scheme='xterm').convert(sample, full=False, ensure_trailing_newline=False)
+        expected = six.u('<span style="color: #cdcd00">YELLOW/BROWN</span>')
+        self.assertEqual(expected, html)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The colors in the HTML didnt seem right to me :)

After a research (http://en.wikipedia.org/wiki/ANSI_escape_code#Colors),
it seems ansi2html uses a scheme very close to VGA.

I added an option to select schemes and added "xterm" and "xterm-bright" schemes. 
