### PR TITLE
add empty title element to head section in html output

### DIFF
--- a/ansi2html/converter.py
+++ b/ansi2html/converter.py
@@ -66,6 +66,7 @@ _template = six.u("""<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=%(output_encoding)s">
+<title></title>
 <style type="text/css">\n%(style)s\n</style>
 </head>
 <body class="body_foreground body_background" style="font-size: %(font_size)s;" >


### PR DESCRIPTION
from http://www.w3.org/TR/REC-html40/struct/global.html#h-7.4.2

```
Every HTML document must have a TITLE element in the HEAD
section.
```
