### PR TITLE
Fix CursorMoveUp (ESC[<N>A;) rendering error

### DIFF
--- a/ansi2html/converter.py
+++ b/ansi2html/converter.py
@@ -282,7 +282,12 @@ class Ansi2HTMLConverter(object):
 
             # Special cursor-moving code.  The only supported one.
             if command == 'A':
-                yield CursorMoveUp
+                try:
+                    # params is the number of lines to move up
+                    for i in range(int(params)):
+                        yield CursorMoveUp
+                except ValueError:
+                    yield CursorMoveUp
                 continue
 
             try:
@@ -380,11 +385,20 @@ class Ansi2HTMLConverter(object):
 
             # Go back, deleting every token in the last 'line'
             if part == CursorMoveUp:
-                if final_parts:
-                    final_parts.pop()
+                popped = False
 
+                # one line may have beeen separated into multiple parts, 
+                # if the last parts doesn't contain '\n', they belong to
+                # the same line
                 while final_parts and '\n' not in final_parts[-1]:
+                    popped = True
                     final_parts.pop()
+  
+                # remove the last 'line' from part
+                # one $part may contain multiple lines
+                if final_parts and not popped:
+                    second_last_newline = final_parts[-1][:-1].rfind('\n')
+                    final_parts[-1] = final_parts[-1][:second_last_newline + 1]
 
                 continue
 


### PR DESCRIPTION
In the original implementation, one `part` may actually contain multiple lines. However, the `_collapse_cursor` method may remove multiple lines in some cases.

This patch fixes above issue and supports multiple CursorMoveUp's.

Here's the case that was rendered incorrectly:
https://s3.amazonaws.com/tigergraph-misc/public/render_test.log