### PR TITLE
Refactor packaging and officialy retire support for python <= 3.6

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,13 +16,13 @@ Inspired by and developed off of the work of `pixelbeat`_ and `blackjack`_.
 Build Status
 ------------
 
-.. |master| image:: https://secure.travis-ci.org/ralphbean/ansi2html.png?branch=master
+.. |master| image:: https://github.com/pycontribs/ansi2html/workflows/tox/badge.svg?branch=master
    :alt: Build Status - master branch
-   :target: http://travis-ci.org/#!/ralphbean/ansi2html
+   :target: https://github.com/pycontribs/ansi2html/actions?query=workflow%3Atox+branch%3Amaster
 
-.. |develop| image:: https://secure.travis-ci.org/ralphbean/ansi2html.png?branch=develop
+.. |develop| image:: https://github.com/pycontribs/ansi2html/workflows/tox/badge.svg?branch=develop
    :alt: Build Status - develop branch
-   :target: http://travis-ci.org/#!/ralphbean/ansi2html
+   :target: https://github.com/pycontribs/ansi2html/actions?query=workflow%3Atox+branch%3Adevelop
 
 +----------+-----------+
 | Branch   | Status    |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+requires = [
+  "setuptools >= 41.0.0",
+  "setuptools_scm >= 1.15.0",
+  "setuptools_scm_git_archive >= 1.0",
+  "wheel",
+]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,47 @@
+[metadata]
+name = ansi2html
+url = https://github.com/pycontribs/ansi2html
+project_urls =
+    Bug Tracker = https://github.com/pycontribs/ansi2html/issues
+    Release Management = https://github.com/pycontribs/ansi2html/releases
+    CI = https://github.com/pycontribs/ansi2html/actions
+    Source Code = https://github.com/pycontribs/ansi2html
+long_description = file: README.rst
+long_description_content_type = text/x-rst
+author = 'Ralph Bean'
+author_email = 'rbean@redhat.com'
+classifiers =
+    Development Status :: 5 - Production/Stable
+    License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)
+    Intended Audience :: Developers
+    Intended Audience :: System Administrators
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Topic :: Text Processing
+    Topic :: Text Processing :: Markup
+    Topic :: Text Processing :: Markup :: HTML
+
 [bdist_rpm]
-requires = python >= 2.6.6
-           python-six >= 1.7.3
+requires = python >= 3.6
+
+[options]
+use_scm_version = True
+python_requires = >=3.6
+packages = find:
+include_package_data = True
+zip_safe = False
+
+# These are required during `setup.py` run:
+setup_requires =
+    setuptools_scm >= 1.15.0
+    setuptools_scm_git_archive >= 1.0
+
+# These are required in actual runtime:
+install_requires =
+    six
+
+[options.packages.find]
+where = .

--- a/setup.py
+++ b/setup.py
@@ -1,114 +1,15 @@
-#!/usr/bin/env python
-#  This file is part of ansi2html
-#  Convert ANSI (terminal) colours and attributes to HTML
-#  Copyright (C) 2012  Ralph Bean <rbean@redhat.com>
-#
-#  Inspired by and developed off of the work by pixelbeat and blackjack.
-#
-#  This program is free software: you can redistribute it and/or
-#  modify it under the terms of the GNU General Public License as
-#  published by the Free Software Foundation, either version 3 of
-#  the License, or (at your option) any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-#  General Public License for more details.
-#
-#  You should have received a copy of the GNU General Public License
-#  along with this program.  If not, see
-#  <http://www.gnu.org/licenses/>.
-
-try:
-    from setuptools import setup, find_packages
-except ImportError:
-    from ez_setup import use_setuptools
-    use_setuptools()
-    from setuptools import setup, find_packages
-
+#! /usr/bin/env python
+import site
 import sys
-import os
 
-f = open('README.rst')
-long_description = f.read().strip()
-long_description = long_description.split('split here', 1)[1]
-f.close()
+import setuptools
 
-# Ridiculous as it may seem, we need to import multiprocessing and
-# logging here in order to get tests to pass smoothly on python 2.7.
-try:
-    # no multiprocessing in python < 2.6
-    import multiprocessing
-except ImportError:
-    pass
+# See https://github.com/pypa/pip/issues/7953
+site.ENABLE_USER_SITE = "--user" in sys.argv[1:]
 
-import logging
 
-requires = [
-    'six',  # For python3 support
-]
-
-if sys.version_info[0] == 2 and sys.version_info[1] < 7:
-    requires.append("ordereddict")
-
-data_files = []
-
-# We tried installing manpages with setuptools & co but it had all kinds of
-# "sandbox violation" issues that were inconsistent and wonky.  Therefore, we
-# don't do this anymore and instead just ship man pages with the tarball.
-if False:
-    # Conditionally install man pages into the system or the virtualenv.
-    if 'VIRTUAL_ENV' in os.environ:
-        man_prefix = os.environ['VIRTUAL_ENV']
-    else:
-        man_prefix = '/usr'
-
-    data_files.append(tuple(
-        man_prefix + '/share/man/man1/',
-        ['man/ansi2html.1'],
-    ))
-
-version = '1.5.2'
-
-if '--version' in sys.argv:
-    print(version)
-    sys.exit(0)
-
-setup(
-    name='ansi2html',
-    version=version,
-    description="Convert text with ANSI color codes to HTML",
-    long_description=long_description,
-    author='Ralph Bean',
-    author_email='rbean@redhat.com',
-    url='http://github.com/ralphbean/ansi2html/',
-    license='LGPLv3+',
-    classifiers=[
-        "Development Status :: 5 - Production/Stable",
-        "License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)",
-        "Intended Audience :: Developers",
-        "Intended Audience :: System Administrators",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: 3.6",
-        "Topic :: Text Processing",
-        "Topic :: Text Processing :: Markup",
-        "Topic :: Text Processing :: Markup :: HTML",
-    ],
-    install_requires=requires,
-    tests_require=[
-        'nose',
-        'mock>=0.8',
-    ],
-    test_suite='nose.collector',
-    packages=['ansi2html'],
-    data_files=data_files,
-    include_package_data=True,
-    zip_safe=False,
-    entry_points="""
-    [console_scripts]
-    ansi2html = ansi2html.converter:main
-    """
-)
+if __name__ == "__main__":
+    setuptools.setup(
+        use_scm_version={"local_scheme": "no-local-version"},
+        setup_requires=["setuptools_scm[toml]>=3.5.0"],
+    )

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 3.9.0
-envlist = 
-    py{27,35,36,37,38,39}
+envlist =
+    py{36,37,38,39}
     packaging
 
 [testenv]
@@ -28,15 +28,13 @@ deps =
 setenv =
 commands =
     rm -rfv {toxinidir}/dist/
-    ; TODO: replace old setup.py with pep517
-    python setup.py bdist_wheel sdist
-    ; python -m pep517.build \
-    ;   --source \
-    ;   --binary \
-    ;   --out-dir {toxinidir}/dist/ \
-    ;   {toxinidir}
+    python -m pep517.build \
+      --source \
+      --binary \
+      --out-dir {toxinidir}/dist/ \
+      {toxinidir}
     # metadata validation
     sh -c "python -m twine check {toxinidir}/dist/*"
 whitelist_externals =
+    rm
     sh
-


### PR DESCRIPTION
* Replace old setup.py based packaging with modern pep517 based one, while keeping existing metadata.
* Updates CI urls in readme
