### PR TITLE
Add API documentation generation as part of the build worflow

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -122,3 +122,23 @@ jobs:
         uses: pypa/gh-action-pypi-publish@master
         with:
           password: ${{ secrets.pypi_password }}
+      - name: Build API documentation
+        run: tox -e apidocs
+      - name: Publish API documentation (stable)
+        if: >- 
+            github.event_name == 'create' &&
+            github.event.ref_type == 'tag'
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./build/apidocs
+          destination_dir: stable
+          commit_message: "Update API documentation (stable)"
+      - name: Publish API documentation (latest)
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./build/apidocs
+          destination_dir: latest
+          commit_message: "Update API documentation (latest)"
+      

--- a/README.rst
+++ b/README.rst
@@ -65,6 +65,17 @@ Source:  http://github.com/ralphbean/ansi2html/
 
 pypi:    http://pypi.python.org/pypi/ansi2html/
 
+API documentation
+-----------------
+
++----------+----------------------------------------------------------+
+| Status   | Link                                                     |
++==========+==========================================================+
+| latest   | `HERE <https://pycontribs.github.io/ansi2html/latest>`_  |
++----------+----------------------------------------------------------+
+| stable   | `HERE <https://pycontribs.github.io/ansi2html/stable>`_  |
++----------+----------------------------------------------------------+
+
 License
 -------
 

--- a/ansi2html/__init__.py
+++ b/ansi2html/__init__.py
@@ -1,3 +1,9 @@
+"""
+Welcome to ``ansi2html`` API documentation!
+
+:see: `Ansi2HTMLConverter`
+"""
+
 from ansi2html.converter import Ansi2HTMLConverter
 
 __all__ = ["Ansi2HTMLConverter"]

--- a/ansi2html/converter.py
+++ b/ansi2html/converter.py
@@ -250,6 +250,7 @@ class Ansi2HTMLConverter:
     """Convert Ansi color codes to CSS+HTML
 
     Example:
+    
     >>> conv = Ansi2HTMLConverter()
     >>> ansi = " ".join(sys.stdin.readlines())
     >>> html = conv.convert(ansi)

--- a/apidocs.sh
+++ b/apidocs.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# This shell script builds the apidocs for ansi2html
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+# Stop if errors
+set -euo pipefail
+IFS=$'\n\t,'
+
+# Figure the project version
+project_version="$(python3 setup.py -V)"
+
+# Figure commit ref
+git_sha="$(git rev-parse HEAD)"
+if ! git describe --exact-match --tags > /dev/null 2>&1 ; then
+    is_tag=false
+else
+    git_sha="$(git describe --exact-match --tags)"
+    is_tag=true
+fi
+
+# Init docs folder
+docs_folder="$SCRIPT_DIR/build/apidocs"
+rm -rf "${docs_folder}"
+mkdir -p "${docs_folder}"
+
+# Run pydoctor build
+pydoctor \
+    --project-name="ansi2html ${project_version}" \
+    --project-url="https://github.com/pycontribs/ansi2html/" \
+    --html-viewsource-base="https://github.com/pycontribs/ansi2html/tree/${git_sha}" \
+    --make-html --quiet \
+    --project-base-dir="$SCRIPT_DIR"\
+    --docformat=restructuredtext \
+    --intersphinx=https://docs.python.org/3/objects.inv \
+    --html-output="${docs_folder}" \
+    ./ansi2html
+
+echo "API docs generated in ${docs_folder}"

--- a/apidocs.sh
+++ b/apidocs.sh
@@ -29,7 +29,7 @@ pydoctor \
     --project-name="ansi2html ${project_version}" \
     --project-url="https://github.com/pycontribs/ansi2html/" \
     --html-viewsource-base="https://github.com/pycontribs/ansi2html/tree/${git_sha}" \
-    --make-html --quiet \
+    --make-html --quiet -W \
     --project-base-dir="$SCRIPT_DIR"\
     --docformat=restructuredtext \
     --intersphinx=https://docs.python.org/3/objects.inv \

--- a/tox.ini
+++ b/tox.ini
@@ -53,3 +53,12 @@ commands =
 whitelist_externals =
     rm
     sh
+
+[testenv:apidocs]
+description = Build the API documentation
+deps = 
+    docutils 
+    pydoctor
+usedevelop = false
+commands = {toxinidir}/apidocs.sh
+    


### PR DESCRIPTION
Hi,

This PR adds API documentation with `pydoctor`. 

This avoids having to skim through the code to find the right arguments to the `convert` function for instance. 