### PR TITLE
Bump setuptools-scm version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
   "setuptools >= 41.0.0",
-  "setuptools_scm >= 1.15.0",
+  "setuptools_scm >= 6.0.1",
   "setuptools_scm_git_archive >= 1.0",
   "wheel",
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ zip_safe = False
 
 # These are required during `setup.py` run:
 setup_requires =
-    setuptools_scm >= 1.15.0
+    setuptools_scm >= 6.0.1
     setuptools_scm_git_archive >= 1.0
 
 [options.entry_points]

--- a/setup.py
+++ b/setup.py
@@ -11,5 +11,5 @@ site.ENABLE_USER_SITE = "--user" in sys.argv[1:]
 if __name__ == "__main__":
     setuptools.setup(
         use_scm_version={"local_scheme": "no-local-version"},
-        setup_requires=["setuptools_scm[toml]>=3.5.0"],
+        setup_requires=["setuptools_scm>=6.0.1"],
     )


### PR DESCRIPTION
Sorts issue observed with newer setuptools-scm which dropped toml extra. Also reduces the variance regarding library versions. Keep in mind that these are setup/build requirements and not runtime ones. When installing from wheel they should not even be needed.