### PR TITLE
Add flake8 plugin `flake8-pytest-style` and use a regular `assert` instead of unittest-style `assertEqual()`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,7 @@ repos:
           - flake8-docstrings>=1.6.0
           - flake8-absolute-import>=1.0
           - flake8-black>=0.2.3
+          - flake8-pytest-style>=1.5.0
         language_version: python3
   - repo: https://github.com/pycqa/pylint
     rev: v2.10.2

--- a/tests/test_ansi2html.py
+++ b/tests/test_ansi2html.py
@@ -95,7 +95,7 @@ class TestAnsi2HTML(unittest.TestCase):
             if html and html[-1] == "":
                 html = html[:-1]
 
-            self.assertEqual("\n".join(html), "\n".join(expected_data))
+            assert "\n".join(html) == "\n".join(expected_data)
 
     @patch("sys.argv", new_callable=lambda: ["ansi2html"])
     @patch("sys.stdout", new_callable=StringIO)
@@ -116,7 +116,7 @@ class TestAnsi2HTML(unittest.TestCase):
 
         html = mock_stdout.getvalue()
 
-        self.assertEqual(html, expected_data)
+        assert html == expected_data
 
     def test_unicode(self) -> None:
         """Ensure that the converter returns unicode(py2)/str(py3) objs."""
@@ -171,7 +171,7 @@ class TestAnsi2HTML(unittest.TestCase):
         )
         assert isinstance(html, str)
         assert isinstance(expected, str)
-        self.assertEqual(expected, html)
+        assert expected == html
 
     def test_partial(self) -> None:
         rainbow = "\x1b[1m\x1b[40m\x1b[31mr\x1b[32ma\x1b[33mi\x1b[34mn\x1b[35mb\x1b[36mo\x1b[37mw\x1b[0m\n"
@@ -188,7 +188,7 @@ class TestAnsi2HTML(unittest.TestCase):
             + '<span class="ansi1 ansi36 ansi40">o</span>'
             + '<span class="ansi1 ansi37 ansi40">w</span>'
         )
-        self.assertEqual(expected, html)
+        assert expected == html
 
     def test_inline(self) -> None:
 
@@ -207,7 +207,7 @@ class TestAnsi2HTML(unittest.TestCase):
             + '<span style="font-weight: bold; color: #F5F1DE; background-color: #000316">w</span>'
         )
 
-        self.assertEqual(expected, html)
+        assert expected == html
 
     def test_produce_headers(self) -> None:
         conv = Ansi2HTMLConverter()
@@ -217,37 +217,37 @@ class TestAnsi2HTML(unittest.TestCase):
         with open(inputfile, "rb") as produce_headers:
             expected_data = read_to_unicode(produce_headers)
 
-        self.assertMultiLineEqual(headers, "".join(expected_data))
+        assert headers == "".join(expected_data)
 
     def test_escaped_implicit(self) -> None:
         test = "<p>awesome</p>"
         expected = "&lt;p&gt;awesome&lt;/p&gt;"
         html = Ansi2HTMLConverter().convert(test, full=False)
-        self.assertEqual(expected, html)
+        assert expected == html
 
     def test_escaped_explicit(self) -> None:
         test = "<p>awesome</p>"
         expected = "&lt;p&gt;awesome&lt;/p&gt;"
         html = Ansi2HTMLConverter(escaped=True).convert(test, full=False)
-        self.assertEqual(expected, html)
+        assert expected == html
 
     def test_unescaped(self) -> None:
         test = "<p>awesome</p>"
         expected = "<p>awesome</p>"
         html = Ansi2HTMLConverter(escaped=False).convert(test, full=False)
-        self.assertEqual(expected, html)
+        assert expected == html
 
     def test_markup_lines(self) -> None:
         test = "  wat  \n "
         expected = '<span id="line-0">  wat  </span>\n<span id="line-1"> </span>'
         html = Ansi2HTMLConverter(markup_lines=True).convert(test, full=False)
-        self.assertEqual(expected, html)
+        assert expected == html
 
     def test_no_markup_lines(self) -> None:
         test = "  wat  \n "
         expected = test
         html = Ansi2HTMLConverter().convert(test, full=False)
-        self.assertEqual(expected, html)
+        assert expected == html
 
     def test_issue_25(self) -> None:
         sample = "\x1b[0;38;5;238;48;5;231mTEXT\x1b[0m"
@@ -255,7 +255,7 @@ class TestAnsi2HTML(unittest.TestCase):
         html = Ansi2HTMLConverter(inline=False).convert(sample, full=False)
         expected = '<span class="ansi38-238 ansi48-231">TEXT</span>'
 
-        self.assertEqual(expected, html)
+        assert expected == html
 
     def test_italic(self) -> None:
         sample = "\x1b[3mITALIC\x1b[0m"
@@ -263,7 +263,7 @@ class TestAnsi2HTML(unittest.TestCase):
         html = Ansi2HTMLConverter(inline=True).convert(sample, full=False)
         expected = '<span style="font-style: italic">ITALIC</span>'
 
-        self.assertEqual(expected, html)
+        assert expected == html
 
     def test_hidden_text(self) -> None:
         sample = "\x1b[%dmHIDDEN\x1b[%dmVISIBLE\x1b[0m" % (
@@ -274,7 +274,7 @@ class TestAnsi2HTML(unittest.TestCase):
         html = Ansi2HTMLConverter(inline=True).convert(sample, full=False)
         expected = '<span style="visibility: hidden">HIDDEN</span>VISIBLE'
 
-        self.assertEqual(expected, html)
+        assert expected == html
 
     def test_lighter_text(self) -> None:
         sample = "NORMAL\x1b[%dmLIGHTER\x1b[%dmBOLD\x1b[%dmNORMAL" % (
@@ -286,7 +286,7 @@ class TestAnsi2HTML(unittest.TestCase):
         html = Ansi2HTMLConverter(inline=True).convert(sample, full=False)
         expected = 'NORMAL<span style="font-weight: lighter">LIGHTER</span><span style="font-weight: bold">BOLD</span>NORMAL'
 
-        self.assertEqual(expected, html)
+        assert expected == html
 
     def test_blinking_text(self) -> None:
         sample = "\x1b[%dm555\x1b[%dm666\x1b[%dmNOBLINK\x1b[0m" % (
@@ -297,11 +297,11 @@ class TestAnsi2HTML(unittest.TestCase):
 
         html = Ansi2HTMLConverter(inline=True).convert(sample, full=False)
         expected = '<span style="text-decoration: blink">555</span><span style="text-decoration: blink">666</span>NOBLINK'
-        self.assertEqual(expected, html)
+        assert expected == html
 
         html = Ansi2HTMLConverter(inline=False).convert(sample, full=False)
         expected = '<span class="ansi5">555</span><span class="ansi6">666</span>NOBLINK'
-        self.assertEqual(expected, html)
+        assert expected == html
 
     def test_inverse_text(self) -> None:
         sample = "NORMAL\x1b[%dmINVERSE\x1b[%dmNORMAL\x1b[0m" % (
@@ -312,7 +312,7 @@ class TestAnsi2HTML(unittest.TestCase):
         expected = (
             'NORMAL<span class="inv_background inv_foreground">INVERSE</span>NORMAL'
         )
-        self.assertEqual(expected, html)
+        assert expected == html
 
         sample = "NORMAL\x1b[%dm303030\x1b[%dm!30!30!30\x1b[%dm303030\x1b[0m" % (
             30,
@@ -321,7 +321,7 @@ class TestAnsi2HTML(unittest.TestCase):
         )
         html = Ansi2HTMLConverter(inline=False).convert(sample, full=False)
         expected = 'NORMAL<span class="ansi30">303030</span><span class="inv30 inv_foreground">!30!30!30</span><span class="ansi30">303030</span>'
-        self.assertEqual(expected, html)
+        assert expected == html
 
         sample = (
             "NORMAL\x1b[%dm313131\x1b[%dm!31!31!31\x1b[%dm!31!43\x1b[%dm31+43\x1b[0mNORMAL"
@@ -329,7 +329,7 @@ class TestAnsi2HTML(unittest.TestCase):
         )
         html = Ansi2HTMLConverter(inline=False).convert(sample, full=False)
         expected = 'NORMAL<span class="ansi31">313131</span><span class="inv31 inv_foreground">!31!31!31</span><span class="inv31 inv43">!31!43</span><span class="ansi31 ansi43">31+43</span>NORMAL'
-        self.assertEqual(expected, html)
+        assert expected == html
 
     def test_cross_line_state(self) -> None:  # covers issue 36, too
         sample = "\x1b[31mRED\nSTILL RED"
@@ -337,35 +337,35 @@ class TestAnsi2HTML(unittest.TestCase):
             sample, full=False, ensure_trailing_newline=False
         )
         expected = '<span style="color: #aa0000">RED\nSTILL RED</span>'
-        self.assertEqual(expected, html)
+        assert expected == html
 
         sample = "\x1b[31mRED\nSTILL RED\n"
         html = Ansi2HTMLConverter(inline=True).convert(
             sample, full=False, ensure_trailing_newline=False
         )
         expected = '<span style="color: #aa0000">RED\nSTILL RED\n</span>'
-        self.assertEqual(expected, html)
+        assert expected == html
 
         sample = "\x1b[31mRED\nSTILL RED"
         html = Ansi2HTMLConverter(inline=True).convert(
             sample, full=False, ensure_trailing_newline=True
         )
         expected = '<span style="color: #aa0000">RED\nSTILL RED</span>\n'
-        self.assertEqual(expected, html)
+        assert expected == html
 
         sample = "\x1b[31mRED\nSTILL RED\n"
         html = Ansi2HTMLConverter(inline=True).convert(
             sample, full=False, ensure_trailing_newline=True
         )
         expected = '<span style="color: #aa0000">RED\nSTILL RED\n</span>\n'
-        self.assertEqual(expected, html)
+        assert expected == html
 
         sample = "\x1b[31mRED\nSTILL RED\x1b[m\n"
         html = Ansi2HTMLConverter(inline=True).convert(
             sample, full=False, ensure_trailing_newline=True
         )
         expected = '<span style="color: #aa0000">RED\nSTILL RED</span>\n'
-        self.assertEqual(expected, html)
+        assert expected == html
 
     def test_scheme(self) -> None:  # covers issue 36, too
         sample = "\x1b[33mYELLOW/BROWN"
@@ -374,14 +374,14 @@ class TestAnsi2HTML(unittest.TestCase):
             sample, full=False, ensure_trailing_newline=False
         )
         expected = '<span style="color: #aa5500">YELLOW/BROWN</span>'
-        self.assertEqual(expected, html)
+        assert expected == html
 
         # xterm scheme is yellow #cdcd00
         html = Ansi2HTMLConverter(inline=True, scheme="xterm").convert(
             sample, full=False, ensure_trailing_newline=False
         )
         expected = '<span style="color: #cdcd00">YELLOW/BROWN</span>'
-        self.assertEqual(expected, html)
+        assert expected == html
 
     def test_latex_inline(self) -> None:
         ansi = "\x1b[33mYELLOW/BROWN"

--- a/tests/test_ansi2html.py
+++ b/tests/test_ansi2html.py
@@ -22,7 +22,6 @@
 #  <http://www.gnu.org/licenses/>.
 
 import textwrap
-import unittest
 from io import StringIO
 from os.path import abspath, dirname, join
 from subprocess import run
@@ -49,7 +48,7 @@ from ansi2html.util import read_to_unicode
 _here = dirname(abspath(__file__))
 
 
-class TestAnsi2HTML(unittest.TestCase):
+class TestAnsi2HTML:
     maxDiff = None
 
     def test_linkify(self) -> None:
@@ -409,7 +408,3 @@ class TestAnsi2HTML(unittest.TestCase):
     def test_command_module(self) -> None:
         result = run(["python3", "-m", "ansi2html", "--version"], check=True)
         assert result.returncode == 0
-
-
-if __name__ == "__main__":
-    unittest.main()


### PR DESCRIPTION
This PR:

- adds `flake8-pytest-style`: a flake8 plugin checking common style issues or inconsistencies with pytest-based tests
- changes tests to use a regular `assert` instead of unittest-style `assertEqual()`:
  - to enforce the assertion style recommended by pytest
  - to make use of pytest's assertion rewriting
- removes unused `unittest` references as pytest ist used for testing

For changing the assertion style also see: https://github.com/m-burst/flake8-pytest-style/blob/v1.5.0/docs/rules/PT009.md