### PR TITLE
Update linting dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,8 +4,8 @@ repos:
     rev: 5.9.3
     hooks:
       - id: isort
-  - repo: https://github.com/python/black.git
-    rev: 21.8b0
+  - repo: https://github.com/psf/black.git
+    rev: 21.9b0
     hooks:
       - id: black
         language_version: python3
@@ -21,14 +21,14 @@ repos:
       - id: debug-statements
         language_version: python3
   - repo: https://gitlab.com/pycqa/flake8.git
-    rev: 3.9.2
+    rev: 4.0.1
     hooks:
       - id: flake8
         additional_dependencies:
-          - pydocstyle>=5.1.1
-          - flake8-absolute-import
-          - flake8-black>=0.1.1
-          - flake8-docstrings>=1.5.0
+          - pydocstyle>=6.1.1
+          - flake8-docstrings>=1.6.0
+          - flake8-absolute-import>=1.0
+          - flake8-black>=0.2.3
         language_version: python3
   - repo: https://github.com/pycqa/pylint
     rev: v2.10.2


### PR DESCRIPTION
updating build dependencies and linting

 - bump flake8 to 4.0.1
 - bump pydocstyle to 6.1.1
 - bump flake8-docstrings to 1.6.0
 - bump flake8-absolute-import to 1.0
 - bump flake8-black to 0.2.3
 - bump black to 21.9b0 (also repositoy for black moved to https://github.com/psf/black.git)