### PR TITLE
remove `--sdist` and `--wheel` because they are implicit

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -46,8 +46,6 @@ setenv =
 commands =
     rm -rfv {toxinidir}/dist/
     python -m build \
-      --sdist \
-      --wheel \
       --outdir {toxinidir}/dist/ \
       {toxinidir}
     # metadata validation


### PR DESCRIPTION
As discussed in PR #145 removing the implicit building options as they
disable the default behavior. According to the documentation:

> By default, a source distribution (sdist) is built from {srcdir} and
> a binary distribution (wheel) is built from the sdist. This is recommended
> as it will ensure the sdist can be used to build wheels.
> Pass -s/–sdist and/or -w/–wheel to build a specific distribution.
> If you do this, the default behavior will be disabled, and all artifacts
> will be built from {srcdir} (even if you combine -w/–wheel with -s/–sdist,
> the wheel will be built from {srcdir}).