### PR TITLE
style.py: Get CSS class .inv_foreground in sync with .body_foreground

### DIFF
--- a/ansi2html/style.py
+++ b/ansi2html/style.py
@@ -210,7 +210,7 @@ def get_styles(
             color=("#000000", "#FFFFFF")[dark_bg],
             font_weight=("bold", "normal")[dark_bg],
         ),
-        Rule(".inv_foreground", color=("#000000", "#FFFFFF")[not dark_bg]),
+        Rule(".inv_foreground", color=("#000000", "#AAAAAA")[not dark_bg]),
         Rule(".inv_background", background_color=("#AAAAAA", "#000000")[not dark_bg]),
         # These effects are "SGR (Select Graphic Rendition) parameters"
         # https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_(Select_Graphic_Rendition)_parameters


### PR DESCRIPTION
`.inv*` CSS classes [were meant to be](../commit/408808197e9b33aa55210b5f03940267b3e01c83) the exact opposite of their counterpart. So with `Rule(".body_foreground", color=("#000000", "#AAAAAA")[dark_bg])` then class `.inv_foreground` should have been `#AAAAAA` rather than `#FFFFFF` from the beginning.