### PR TITLE
fix regression added in PR #143

### DIFF
--- a/ansi2html/converter.py
+++ b/ansi2html/converter.py
@@ -20,6 +20,7 @@
 #  along with this program.  If not, see
 #  <http://www.gnu.org/licenses/>.
 
+import io
 import optparse
 import re
 import sys
@@ -786,6 +787,8 @@ def main() -> None:
         title=opts.output_title,
     )
 
+    reader = io.TextIOWrapper(sys.stdin.buffer, opts.input_encoding, "replace")
+
     def _print(output_unicode: str, end: str = "\n") -> None:
         if hasattr(sys.stdout, "buffer"):
             output_bytes = (output_unicode + end).encode(opts.output_encoding)
@@ -800,6 +803,6 @@ def main() -> None:
 
     full = not bool(opts.partial or opts.inline)
     output = conv.convert(
-        "".join(sys.stdin.readlines()), full=full, ensure_trailing_newline=True
+        "".join(reader.readlines()), full=full, ensure_trailing_newline=True
     )
     _print(output, end="")

--- a/tests/test_ansi2html.py
+++ b/tests/test_ansi2html.py
@@ -22,7 +22,7 @@
 #  <http://www.gnu.org/licenses/>.
 
 import textwrap
-from io import StringIO
+from io import BytesIO, StringIO, TextIOWrapper
 from os.path import abspath, dirname, join
 from subprocess import run
 from typing import List
@@ -107,10 +107,10 @@ class TestAnsi2HTML:
         with open(join(_here, "ansicolor.html"), "rb") as output:
             expected_data = "".join(read_to_unicode(output))
 
-        def f() -> StringIO:
-            return StringIO(test_data)
-
-        with patch("sys.stdin", new_callable=f):
+        with patch(
+            "sys.stdin",
+            new_callable=lambda: TextIOWrapper(BytesIO(test_data.encode("utf-8"))),
+        ):
             main()
 
         html = mock_stdout.getvalue()
@@ -140,7 +140,10 @@ class TestAnsi2HTML:
         """
         )
 
-        with patch("sys.stdin", new_callable=lambda: StringIO(test_input)):
+        with patch(
+            "sys.stdin",
+            new_callable=lambda: TextIOWrapper(BytesIO(test_input.encode("utf-8"))),
+        ):
             main()
 
         ms_val = mock_stdout.getvalue()
@@ -151,8 +154,13 @@ class TestAnsi2HTML:
     def test_partial_as_command(
         self, mock_stdout: StringIO, mock_argv: List[str]
     ) -> None:
+
         rainbow = "\x1b[1m\x1b[40m\x1b[31mr\x1b[32ma\x1b[33mi\x1b[34mn\x1b[35mb\x1b[36mo\x1b[37mw\x1b[0m\n"
-        with patch("sys.stdin", new_callable=lambda: StringIO(rainbow)):
+
+        with patch(
+            "sys.stdin",
+            new_callable=lambda: TextIOWrapper(BytesIO(rainbow.encode("utf-8"))),
+        ):
             main()
 
         html = mock_stdout.getvalue().strip()
@@ -178,7 +186,10 @@ class TestAnsi2HTML:
         self, mock_stdout: StringIO, mock_argv: List[str]
     ) -> None:
 
-        main()
+        with patch(
+            "sys.stdin", new_callable=lambda: TextIOWrapper(BytesIO("".encode("utf-8")))
+        ):
+            main()
 
         with open(join(_here, "produce_headers.txt"), "rb") as produce_headers:
             expected = read_to_unicode(produce_headers)


### PR DESCRIPTION
While adding type-hinting the option to specify an input encoding
got ignored. This commit fixes this regression.

This commit also fixes the tests which call ansi2html as a command.
As the pytest documentation states, during test execution `stdin`
is set to a “null” object which will fail on attempts to read from it
because it is rarely desired to wait for interactive input when
running automated tests. So we also patch now `sys.stdin` using an
`io.TextIOWrapper` and wrapping any actual input in a `io.BytesIO`.