### PR TITLE
Migrate from mock to unittest.mock of Python >=3.3 (fixes #169)

### DIFF
--- a/tests/test_ansi2html.py
+++ b/tests/test_ansi2html.py
@@ -26,8 +26,7 @@ from io import StringIO
 from os.path import abspath, dirname, join
 from subprocess import run
 from typing import List
-
-from mock import patch
+from unittest.mock import patch
 
 from ansi2html import Ansi2HTMLConverter
 from ansi2html.converter import (

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,6 @@ setenv =
     # PYTHONWARNINGS=error
     COVERAGE_FILE = {env:COVERAGE_FILE:{toxworkdir}/.coverage.{envname}}
 deps =
-    mock
     pytest
     pytest-cov
 sitepackages = False


### PR DESCRIPTION
Fixes #169