### PR TITLE
Fix for ANSI color codes that include blank values

### DIFF
--- a/ansi2html/converter.py
+++ b/ansi2html/converter.py
@@ -454,8 +454,15 @@ class Ansi2HTMLConverter:
                 yield CursorMoveUp()
                 continue
 
+            while True:
+                param_len = len(params)
+                params = params.replace("::", ":")
+                params = params.replace(";;", ";")
+                if len(params) == param_len:
+                    break
+
             try:
-                params = [int(x) for x in re.split("[;:]", params) if len(x) > 0]
+                params = [int(x) for x in re.split("[;:]", params)]
             except ValueError:
                 params = [ANSI_FULL_RESET]
 


### PR DESCRIPTION
Hey, y'all.

I got the developer of wezterm to add a "Copy as ANSI" option, but the truecolor ANSI codes it outputs have some blank values in them (they look like `<esc>[48:2::255:180:69m`).  This here's a fix so that they get parsed correctly.
