### PR TITLE
Update build-system requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,7 @@
 [build-system]
 requires = [
-  "setuptools >= 41.0.0",
-  "setuptools_scm >= 6.0.1",
-  "setuptools_scm_git_archive >= 1.0",
-  "wheel",
+  "setuptools >= 45.0.0",
+  "setuptools_scm[toml] >= 7.0.0",
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
pyproject.toml:
Update build-system requirements for setuptools-scm to >= 7.0.0 which obsoletes setuptools-scm-git-archive.
Remove wheel, as it is not required for a PEP517 workflow with pypa/build and pypa/installer.