### PR TITLE
Custom bg fg colors and css

### DIFF
--- a/src/ansi2html/converter.py
+++ b/src/ansi2html/converter.py
@@ -287,6 +287,14 @@ class Ansi2HTMLConverter:
     >>> conv = Ansi2HTMLConverter()
     >>> ansi = " ".join(sys.stdin.readlines())
     >>> html = conv.convert(ansi)
+
+    Example with Custom CSS Overrides:
+
+    >>> custom_css_content_dict = {'font-family':'"Lucida Console", "Courier New", monospace', 'font-size':'8px'} # produces css like: 'font-family: "Lucida Console", "Courier New", monospace; font-size: 12px;'
+    >>> conv = Ansi2HTMLConverter(custom_bg='#FFFFFF', custom_fg='#FF0000', custom_content_css_dict=custom_css_content_dict)
+    >>> ansi = " ".join(sys.stdin.readlines())
+    >>> html = conv.convert(ansi)
+
     """
 
     def __init__(
@@ -302,8 +310,9 @@ class Ansi2HTMLConverter:
         output_encoding: str = "utf-8",
         scheme: str = "ansi2html",
         title: str = "",
-        custom_bg = None,
-        custom_fg = None,
+        custom_bg: Optional[str] = None,
+        custom_fg: Optional[str] = None,
+        custom_content_css_dict: Optional[dict] = None
     ) -> None:
 
         self.latex = latex
@@ -321,12 +330,13 @@ class Ansi2HTMLConverter:
         self.hyperref = False
         self.custom_bg = custom_bg
         self.custom_fg = custom_fg
+        self.custom_content_css_dict = (custom_content_css_dict or {})
 
         if inline:
             self.styles = dict(
                 [
                     (item.klass.strip("."), item)
-                    for item in get_styles(self.dark_bg, self.line_wrap, self.scheme, custom_bg=self.custom_bg, custom_fg=self.custom_fg)
+                    for item in get_styles(self.dark_bg, self.line_wrap, self.scheme, custom_bg=self.custom_bg, custom_fg=self.custom_fg, custom_content_css_dict=self.custom_content_css_dict)
                 ]
             )
 
@@ -638,7 +648,7 @@ class Ansi2HTMLConverter:
             _template = _latex_template
         else:
             _template = _html_template
-        all_styles = get_styles(self.dark_bg, self.line_wrap, self.scheme, custom_bg=self.custom_bg, custom_fg=self.custom_fg)
+        all_styles = get_styles(self.dark_bg, self.line_wrap, self.scheme, custom_bg=self.custom_bg, custom_fg=self.custom_fg, custom_content_css_dict=self.custom_content_css_dict)
         backgrounds = all_styles[:5]
         used_styles = filter(
             lambda e: e.klass.lstrip(".") in attrs["styles"], all_styles
@@ -656,7 +666,7 @@ class Ansi2HTMLConverter:
     def produce_headers(self) -> str:
         return '<style type="text/css">\n%(style)s\n</style>\n' % {
             "style": "\n".join(
-                map(str, get_styles(self.dark_bg, self.line_wrap, self.scheme, custom_bg=self.custom_bg, custom_fg=self.custom_fg))
+                map(str, get_styles(self.dark_bg, self.line_wrap, self.scheme, custom_bg=self.custom_bg, custom_fg=self.custom_fg, custom_content_css_dict=self.custom_content_css_dict))
             )
         }
 

--- a/src/ansi2html/converter.py
+++ b/src/ansi2html/converter.py
@@ -302,6 +302,8 @@ class Ansi2HTMLConverter:
         output_encoding: str = "utf-8",
         scheme: str = "ansi2html",
         title: str = "",
+        custom_bg = None,
+        custom_fg = None,
     ) -> None:
 
         self.latex = latex
@@ -317,11 +319,14 @@ class Ansi2HTMLConverter:
         self.title = title
         self._attrs: Attributes
         self.hyperref = False
+        self.custom_bg = custom_bg
+        self.custom_fg = custom_fg
+
         if inline:
             self.styles = dict(
                 [
                     (item.klass.strip("."), item)
-                    for item in get_styles(self.dark_bg, self.line_wrap, self.scheme)
+                    for item in get_styles(self.dark_bg, self.line_wrap, self.scheme, custom_bg=self.custom_bg, custom_fg=self.custom_fg)
                 ]
             )
 
@@ -633,7 +638,7 @@ class Ansi2HTMLConverter:
             _template = _latex_template
         else:
             _template = _html_template
-        all_styles = get_styles(self.dark_bg, self.line_wrap, self.scheme)
+        all_styles = get_styles(self.dark_bg, self.line_wrap, self.scheme, custom_bg=self.custom_bg, custom_fg=self.custom_fg)
         backgrounds = all_styles[:5]
         used_styles = filter(
             lambda e: e.klass.lstrip(".") in attrs["styles"], all_styles
@@ -651,7 +656,7 @@ class Ansi2HTMLConverter:
     def produce_headers(self) -> str:
         return '<style type="text/css">\n%(style)s\n</style>\n' % {
             "style": "\n".join(
-                map(str, get_styles(self.dark_bg, self.line_wrap, self.scheme))
+                map(str, get_styles(self.dark_bg, self.line_wrap, self.scheme, custom_bg=self.custom_bg, custom_fg=self.custom_fg))
             )
         }
 

--- a/src/ansi2html/style.py
+++ b/src/ansi2html/style.py
@@ -244,6 +244,8 @@ def get_styles(
     dark_bg: bool = True,
     line_wrap: bool = True,
     scheme: str = "ansi2html",
+    custom_bg = None,
+    custom_fg = None
 ) -> List[Rule]:
     css = [
         Rule(
@@ -252,8 +254,8 @@ def get_styles(
             word_wrap="break-word",
             display="inline",
         ),
-        Rule(".body_foreground", color=("#000000", "#AAAAAA")[dark_bg]),
-        Rule(".body_background", background_color=("#AAAAAA", "#000000")[dark_bg]),
+        Rule(".body_foreground", color=custom_fg or ("#000000", "#AAAAAA")[dark_bg]),
+        Rule(".body_background", background_color=custom_bg or ("#AAAAAA", "#000000")[dark_bg]),
         Rule(".inv_foreground", color=("#000000", "#AAAAAA")[not dark_bg]),
         Rule(".inv_background", background_color=("#AAAAAA", "#000000")[not dark_bg]),
         # These effects are "SGR (Select Graphic Rendition) parameters"

--- a/src/ansi2html/style.py
+++ b/src/ansi2html/style.py
@@ -245,7 +245,8 @@ def get_styles(
     line_wrap: bool = True,
     scheme: str = "ansi2html",
     custom_bg = None,
-    custom_fg = None
+    custom_fg = None,
+    custom_content_css_dict = None
 ) -> List[Rule]:
     css = [
         Rule(
@@ -253,6 +254,7 @@ def get_styles(
             white_space=("pre", "pre-wrap")[line_wrap],
             word_wrap="break-word",
             display="inline",
+            **(custom_content_css_dict or {})
         ),
         Rule(".body_foreground", color=custom_fg or ("#000000", "#AAAAAA")[dark_bg]),
         Rule(".body_background", background_color=custom_bg or ("#AAAAAA", "#000000")[dark_bg]),


### PR DESCRIPTION
I added `custom_bg`, `custom_fg`, and `custom_content_css_dict`  parameters to Ansi2HTMLConverter to enable specifying custom background/foreground colors and css properties because I needed this functionality in my own project.

I believe this also satisfies the feature request mentioned here: #153 

I've never used the CLI interface, so hopefully these properties don't interfere with that functionality (which I haven't tested or looked in to).

```python
# Example with Custom CSS Overrides:
custom_css_content_dict = {'font-family':'"Lucida Console", "Courier New", monospace', 'font-size':'8px'} # produces css like: 'font-family: "Lucida Console", "Courier New", monospace; font-size: 8px;'
conv = Ansi2HTMLConverter(custom_bg='#FFFFFF', custom_fg='#220000', custom_content_css_dict=custom_css_content_dict)
ansi = " ".join(sys.stdin.readlines())
html = conv.convert(ansi)
```

Hope it's helpful to someone.