### PR TITLE
Fix issue #252

### DIFF
--- a/src/ansi2html/converter.py
+++ b/src/ansi2html/converter.py
@@ -547,7 +547,7 @@ class Ansi2HTMLConverter:
                     style = [
                         self.styles[klass].kwl[0][1]
                         for klass in css_classes
-                        if self.styles[klass].kwl[0][0] == "color"
+                        if self.styles.get(klass) and self.styles[klass].kwl[0][0] == "color"
                     ]
                     yield "\\textcolor[HTML]{%s}{" % style[0]
                 else:


### PR DESCRIPTION
As described in issue #252, the dictionary index is not checked for the presence of the key, resulting in a crash. Add check before indexing.