### PR TITLE
Support alive Python versions

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -39,12 +39,12 @@ jobs:
         id: generate_matrix
         uses: ansible/actions/matrix@v1
         with:
-          min_python: "3.7"
+          min_python: "3.10"
           max_python: "3.14"
+          default_python: "3.14"
           other_names: |
             lint
             pkg,docs
-          platforms: linux:ubuntu-22.04,macos:macos-15-intel # py3.7 too old for just linux,macos
 
   build:
     name: ${{ matrix.name }}
@@ -70,11 +70,11 @@ jobs:
             ~/.cache/pre-commit
           key: pre-commit-${{ matrix.name || '?' }}-${{ hashFiles('.pre-commit-config.yaml') }}
 
-      - name: Set up Python ${{ matrix.python_version || '3.9' }}
+      - name: Set up Python ${{ matrix.python_version || '3.10' }}
         uses: actions/setup-python@v7
         with:
           cache: pip
-          python-version: ${{ matrix.python_version || '3.9' }}
+          python-version: ${{ matrix.python_version || '3.10' }}
 
       - name: Install tox
         run: |

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -40,7 +40,7 @@ jobs:
         uses: ansible/actions/matrix@v1
         with:
           min_python: "3.7"
-          max_python: "3.12"
+          max_python: "3.14"
           other_names: |
             lint
             pkg,docs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 # https://peps.python.org/pep-0621/#readme
-requires-python = ">=3.7"
+requires-python = ">=3.10"
 dynamic = ["version"]
 name = "ansi2html"
 description = "Convert text with ANSI color codes to HTML or to LaTeX"
@@ -22,9 +22,6 @@ classifiers = [
   "Operating System :: POSIX",
   "License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.7",
-  "Programming Language :: Python :: 3.8",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -41,10 +38,6 @@ classifiers = [
   "Topic :: Utilities",
 ]
 keywords = ["ansi", "html", "color"]
-dependencies = [
-  'importlib-metadata; python_version<"3.8"',
-  'typing_extensions; python_version<"3.8"'
-]
 
 [project.urls]
 homepage = "https://github.com/pycontribs/ansi2html"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,8 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python",
   "Topic :: Software Development :: Quality Assurance",


### PR DESCRIPTION
Note: there is currently no immediate reason for deprecating old Python, other than because CI images are to disappear one day.